### PR TITLE
Add missing repositoryType in paket.template

### DIFF
--- a/src/Diffract/paket.template
+++ b/src/Diffract/paket.template
@@ -6,5 +6,6 @@ description
     Display a readable diff between two objects
 projectUrl https://github.com/d-edge/Diffract
 repositoryUrl https://github.com/d-edge/Diffract
+repositoryType git
 requireLicenseAcceptance true
 tags Dedge;Diffract;Diff;Equals;Test;Comparison


### PR DESCRIPTION
`paket pack` silently ignores `repositoryUrl` if there isn't a corresponding `repositoryType`.