### PR TITLE
Strip the HTML from README.md before packing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,11 @@ jobs:
         run: dotnet build -c Release --no-restore
       - name: Test
         run: dotnet test -c Release
+      - name: Strip HTML from README
+        uses: Tarmil/strip-markdown-html@v0.1
+        with:
+          input-path: README.md
+          output-path: src/Diffract/README.md
       - name: Pack
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ packages/
 build/
 TestResults/
 .paket/
+src/Diffract/README.md

--- a/src/Diffract/paket.template
+++ b/src/Diffract/paket.template
@@ -13,4 +13,4 @@ tags Dedge;Diffract;Diff;Equals;Test;Comparison
 iconUrl https://raw.githubusercontent.com/d-edge/Diffract/main/diffract-64x64.png
 readme README.md
 files
-    ../../README.md ==> .
+    README.md ==> .


### PR DESCRIPTION
As it turns out, nuget.org doesn't like HTML in the README.

Uses [this GitHub action](https://github.com/Tarmil/strip-markdown-html).