### PR TITLE
Move under DEdge namespace, rename Diffract class to Differ

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ It is particularly useful for unit testing complex objects.
 Here is an example:
 
 ```csharp
+using DEdge.Diffract;
+
 record User(string Name, int Age, string[] Pets);
 
 var expected = new User("Emma", 42, new[] { "Oscar", "Fluffy", "Tibbles" });
 var actual = new User("Andy", 42, new[] { "Oscar", "Sparky" });
 
-Diffract.Assert(expected, actual);
+Differ.Assert(expected, actual);
 ```
 
 The above throws an `AssertionFailedException` with the following message:
@@ -145,28 +147,28 @@ Value dictionary differs:
 
 ## API
 
-Diffract provides the following methods:
+Diffract lives in the namespace `DEdge.Diffract`. Its main API is the class `Differ`, which provides the following methods:
 
 ```csharp
-void Diffract.Assert<T>(T expected, T actual, IDiffer<T> differ = null, PrintParams param = null)
+void Assert<T>(T expected, T actual, IDiffer<T> differ = null, PrintParams param = null)
 ```
 
 Computes the diff between two objects and, if it is not empty, throws an `AssertionFailedException` with the diff as message.
 
 ```csharp
-string Diffract.ToString<T>(T expected, T actual, IDiffer<T> differ = null, PrintParams param = null)
+string ToString<T>(T expected, T actual, IDiffer<T> differ = null, PrintParams param = null)
 ```
 
 Prints the diff between two objects to a string.
 
 ```csharp
-void Diffract.Write<T>(T expected, T actual, TextWriter writer = null, IDiffer<T> differ = null, PrintParams param = null)
+void Write<T>(T expected, T actual, TextWriter writer = null, IDiffer<T> differ = null, PrintParams param = null)
 ```
 
 Prints the diff between two objects to the given TextWriter (or to standard output if not provided).
 
 ```csharp
-FSharpOption<Diff> Diffract.Diff<T>(T expected, T actual, IDiffer<T> differ = null)
+FSharpOption<Diff> Diff<T>(T expected, T actual, IDiffer<T> differ = null)
 ```
 
 Computes the diff between two objects. Returns `None` if the objects are found to be equal.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 <p align="center">
         <a href="https://github.com/d-edge/diffract/actions" title="actions"><img src="https://github.com/d-edge/diffract/actions/workflows/build.yml/badge.svg?branch=main" alt="actions build" /></a>
-    <a href="https://www.nuget.org/packages/diffract/" title="nuget"><img src="https://img.shields.io/nuget/vpre/diffract" alt="version" /></a>
-    <a href="https://www.nuget.org/stats/packages/diffract?groupby=Version" title="stats"><img src="https://img.shields.io/nuget/dt/diffract" alt="download" /></a> 
+    <a href="https://www.nuget.org/packages/dedge.diffract/" title="nuget"><img src="https://img.shields.io/nuget/vpre/dedge.diffract" alt="version" /></a>
+    <a href="https://www.nuget.org/stats/packages/dedge.diffract?groupby=Version" title="stats"><img src="https://img.shields.io/nuget/dt/dedge.diffract" alt="download" /></a> 
     <a href="https://raw.githubusercontent.com/d-edge/diffract/main/LICENSE" title="license"><img src="https://img.shields.io/github/license/d-edge/diffract" alt="license" /></a>
 </p>
 

--- a/src/Diffract/DictionaryShape.fs
+++ b/src/Diffract/DictionaryShape.fs
@@ -1,4 +1,4 @@
-﻿namespace Diffract.DictionaryShape
+﻿namespace DEdge.Diffract.DictionaryShape
 
 open System
 open System.Collections.Generic

--- a/src/Diffract/DiffPrinter.fs
+++ b/src/Diffract/DiffPrinter.fs
@@ -1,4 +1,4 @@
-﻿module Diffract.DiffPrinter
+﻿module DEdge.Diffract.DiffPrinter
 
 open System.IO
 

--- a/src/Diffract/Differ.fs
+++ b/src/Diffract/Differ.fs
@@ -1,14 +1,14 @@
-﻿namespace Diffract
+﻿namespace DEdge.Diffract
 
 #nowarn "40"
 
 open System
 open System.Collections.Generic
 open TypeShape.Core
-open Diffract.ReadOnlyDictionaryShape
-open Diffract.DictionaryShape
+open DEdge.Diffract.ReadOnlyDictionaryShape
+open DEdge.Diffract.DictionaryShape
 
-module Differ =
+module DifferImpl =
 
     type private Cache = Dictionary<Type, IDifferFactory>
     type private CachedDiffer<'T> = Cache -> IDiffer<'T>

--- a/src/Diffract/Diffract.fs
+++ b/src/Diffract/Diffract.fs
@@ -1,4 +1,4 @@
-﻿namespace Diffract
+﻿namespace DEdge.Diffract
 
 open System
 open System.Collections.Generic
@@ -6,7 +6,7 @@ open System.IO
 open System.Runtime.InteropServices
 
 [<AbstractClass; Sealed>]
-type Diffract private () =
+type Differ private () =
 
     static let simplePrintParams : PrintParams =
         {
@@ -24,7 +24,7 @@ type Diffract private () =
         if obj.ReferenceEquals(value, null) then def else value
 
     static let defaultDiffer d =
-        if obj.ReferenceEquals(d, null) then Differ.simple else d
+        if obj.ReferenceEquals(d, null) then DifferImpl.simple else d
 
     /// The default print parameters for simple printing.
     static member SimplePrintParams = simplePrintParams
@@ -36,9 +36,9 @@ type Diffract private () =
     /// <param name="customDiffers">Custom differs to handle specific types.</param>
     static member GetDiffer<'T>([<ParamArray>] customDiffers: ICustomDiffer[]) =
         match customDiffers with
-        | null | [||] -> Differ.simple<'T>
-        | [| customDiffer |] -> Differ.diffWith<'T> customDiffer (Dictionary())
-        | _ -> Differ.diffWith<'T> (CombinedCustomDiffer(customDiffers)) (Dictionary())
+        | null | [||] -> DifferImpl.simple<'T>
+        | [| customDiffer |] -> DifferImpl.diffWith<'T> customDiffer (Dictionary())
+        | _ -> DifferImpl.diffWith<'T> (CombinedCustomDiffer(customDiffers)) (Dictionary())
 
     /// <summary>Compute the diff between two values.</summary>
     /// <param name="expected">The first value to diff.</param>
@@ -65,8 +65,8 @@ type Diffract private () =
     /// <param name="differ">The differ to use. If null, use <see cref="GetDiffer">GetDiffer&lt;T&gt;()</see>.</param>
     /// <param name="param">The printing parameters used to generate the exception message.</param>
     static member Assert<'T>(expected: 'T, actual: 'T, [<Optional>] differ: IDiffer<'T>, [<Optional>] param: PrintParams) =
-        let diff = Diffract.Diff(expected, actual, differ)
-        Diffract.Assert(diff, param)
+        let diff = Differ.Diff(expected, actual, differ)
+        Differ.Assert(diff, param)
 
     /// <summary>Print a diff to a string.</summary>
     /// <param name="diff">The diff to print.</param>
@@ -81,8 +81,8 @@ type Diffract private () =
     /// <param name="differ">The differ to use. If null, use <see cref="GetDiffer">GetDiffer&lt;T&gt;()</see>.</param>
     /// <param name="param">The printing parameters.</param>
     static member ToString<'T>(expected: 'T, actual: 'T, [<Optional>] differ: IDiffer<'T>, [<Optional>] param: PrintParams) =
-        let diff = Diffract.Diff(expected, actual, differ)
-        Diffract.ToString(diff, param)
+        let diff = Differ.Diff(expected, actual, differ)
+        Differ.ToString(diff, param)
 
     /// <summary>Print a diff to a TextWriter.</summary>
     /// <param name="diff">The diff to print.</param>
@@ -100,5 +100,5 @@ type Diffract private () =
     /// <param name="writer">The writer to print to. If null, use standard output.</param>
     /// <param name="param">The printing parameters.</param>
     static member Write<'T>(expected: 'T, actual: 'T, [<Optional>] writer: TextWriter, [<Optional>] differ: IDiffer<'T>, [<Optional>] param: PrintParams) =
-        let diff = Diffract.Diff(expected, actual, differ)
-        Diffract.Write(diff, writer, param)
+        let diff = Differ.Diff(expected, actual, differ)
+        Differ.Write(diff, writer, param)

--- a/src/Diffract/Diffract.fsproj
+++ b/src/Diffract/Diffract.fsproj
@@ -6,6 +6,7 @@
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RepositoryUrl>https://github.com/d-edge/diffract</RepositoryUrl>
+    <AssemblyName>DEdge.Diffract</AssemblyName>
 
     <!-- SourceLink settings -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Diffract/Extensions.fs
+++ b/src/Diffract/Extensions.fs
@@ -1,4 +1,4 @@
-﻿namespace Diffract
+﻿namespace DEdge.Diffract
 
 open System.Collections.Generic
 open System.IO
@@ -15,7 +15,7 @@ type Extensions private () =
     /// <param name="param">The printing parameters used to generate the exception message.</param>
     [<Extension>]
     static member Assert(differ: IDiffer<'T>, expected: 'T, actual: 'T, [<Optional>] param: PrintParams) =
-        Diffract.Assert(expected, actual, differ, param)
+        Differ.Assert(expected, actual, differ, param)
 
     /// <summary>Print a diff to a string.</summary>
     /// <param name="differ">The differ to use.</param>
@@ -24,7 +24,7 @@ type Extensions private () =
     /// <param name="param">The printing parameters.</param>
     [<Extension>]
     static member ToString(differ: IDiffer<'T>, expected: 'T, actual: 'T, [<Optional>] param: PrintParams) =
-        Diffract.ToString(expected, actual, differ, param)
+        Differ.ToString(expected, actual, differ, param)
 
     /// <summary>Print a diff to a TextWriter.</summary>
     /// <param name="differ">The differ to use.</param>
@@ -34,13 +34,13 @@ type Extensions private () =
     /// <param name="param">The printing parameters.</param>
     [<Extension>]
     static member Write(differ: IDiffer<'T>, expected: 'T, actual: 'T, [<Optional>] writer: TextWriter, [<Optional>] param: PrintParams) =
-        Diffract.Write(expected, actual, writer, differ, param)
+        Differ.Write(expected, actual, writer, differ, param)
 
     /// <summary>Get a differ with support for specific types.</summary>
     /// <param name="custom">A custom differ to handle specific types.</param>
     [<Extension>]
     static member GetDiffer<'T>(custom: ICustomDiffer) =
-        Differ.diffWith<'T> custom (Dictionary())
+        DifferImpl.diffWith<'T> custom (Dictionary())
 
     /// <summary>Use in a custom differ to cast a differ for one type into a differ for another type.</summary>
     /// <seealso href="https://github.com/eiriktsarpalis/TypeShape">TypeShape documentation</seealso>

--- a/src/Diffract/ReadOnlyDictionaryShape.fs
+++ b/src/Diffract/ReadOnlyDictionaryShape.fs
@@ -1,4 +1,4 @@
-﻿namespace Diffract.ReadOnlyDictionaryShape
+﻿namespace DEdge.Diffract.ReadOnlyDictionaryShape
 
 open System
 open System.Collections.Generic

--- a/src/Diffract/Types.fs
+++ b/src/Diffract/Types.fs
@@ -1,4 +1,4 @@
-﻿namespace Diffract
+﻿namespace DEdge.Diffract
 
 open System.Collections.Generic
 open System.IO

--- a/src/Diffract/paket.template
+++ b/src/Diffract/paket.template
@@ -1,4 +1,5 @@
 type project
+name DEdge.Diffract
 licenseExpression MIT
 licenseUrl https://licenses.nuget.org/MIT
 authors Loïc Denuzière
@@ -9,7 +10,7 @@ projectUrl https://github.com/d-edge/Diffract
 repositoryUrl https://github.com/d-edge/Diffract
 repositoryType git
 requireLicenseAcceptance true
-tags Dedge;Diffract;Diff;Equals;Test;Comparison
+tags DEdge;Diffract;Diff;Equals;Test;Comparison
 iconUrl https://raw.githubusercontent.com/d-edge/Diffract/main/diffract-64x64.png
 readme README.md
 files

--- a/tests/Diffract.CSharp.Tests/CustomDiffers.cs
+++ b/tests/Diffract.CSharp.Tests/CustomDiffers.cs
@@ -2,7 +2,7 @@
 using TypeShape.Core;
 using Xunit;
 
-namespace Diffract.CSharp.Tests
+namespace DEdge.Diffract.CSharp.Tests
 {
     public class CustomDiffers
     {
@@ -12,7 +12,7 @@ namespace Diffract.CSharp.Tests
             var expectedDiff = "D.X Expect = \"a\"\n    Actual = \"b\"\n";
             var expected = new Container(new CustomDiffable("a"));
             var actual = new Container(new CustomDiffable("b"));
-            var actualDiff = Diffract.ToString(expected, actual);
+            var actualDiff = Differ.ToString(expected, actual);
             Assert.Equal(expectedDiff, actualDiff);
         }
 

--- a/tests/Diffract.CSharp.Tests/Diffract.CSharp.Tests.csproj
+++ b/tests/Diffract.CSharp.Tests/Diffract.CSharp.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <AssemblyName>DEdge.Diffract.CSharp.Tests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Diffract\Diffract.fsproj" />

--- a/tests/Diffract.CSharp.Tests/Tests.cs
+++ b/tests/Diffract.CSharp.Tests/Tests.cs
@@ -1,8 +1,6 @@
-using System;
-using System.Collections.Generic;
 using Xunit;
 
-namespace Diffract.CSharp.Tests
+namespace DEdge.Diffract.CSharp.Tests
 {
     public class Tests
     {
@@ -12,7 +10,7 @@ namespace Diffract.CSharp.Tests
             var expected = new MyPoco { Item = new MyInnerPoco(1, "a", 1) };
             var actual = new MyPoco { Item = new MyInnerPoco(2, "a", 2) };
             Assert.Equal("Item.X Expect = 1\n       Actual = 2\n",
-                Diffract.ToString(expected, actual));
+                Differ.ToString(expected, actual));
         }
 
         [Fact]
@@ -21,7 +19,7 @@ namespace Diffract.CSharp.Tests
             var expected = new MyRecord(1, "a");
             var actual = new MyRecord(2, "a");
             Assert.Equal("X Expect = 1\n  Actual = 2\n",
-                Diffract.ToString(expected, actual));
+                Differ.ToString(expected, actual));
         }
 
         public class MyInnerPoco


### PR DESCRIPTION
Fixes #16.

* Move all code under namespace `DEdge`.
* Rename class `Diffract` to `Differ`.
* Rename module `Differ` to `DifferImpl`. I chose this rather than using `ModuleSuffix` so that as an F# user, when I type `Differ.`, I don't get the contents of both the type and the module in completion.
* Rename NuGet package to `DEdge.Diffract`.