### PR TITLE
ci: Fix build version on non-main branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,10 @@ jobs:
             VERSION="${VERSION//v}"
             echo Clean Version: $VERSION
           else
-            VERSION=$GITHUB_RUN_ID
+            git fetch --prune --unshallow --tags --quiet
+            latestTag=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.1)
+            runId=$GITHUB_RUN_ID
+            VERSION="${latestTag//v}-build.${runId}"
             echo Non-release version: $VERSION
           fi
           dotnet paket pack --symbols --version $VERSION nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Test
         run: dotnet test -c Release
       - name: Strip HTML from README
-        uses: Tarmil/strip-markdown-html@v0.1
+        uses: Tarmil/strip-markdown-html@v0.3
         with:
           input-path: README.md
           output-path: src/Diffract/README.md


### PR DESCRIPTION
Simply using the build number causes an integer overflow. Instead, use the version from git (same as release version) and put the build number in the version suffix.

See the similar issue d-edge/Cardizer#124.