### PR TITLE
Add CustomDiffer functions

### DIFF
--- a/src/Diffract/CustomDiffer.fs
+++ b/src/Diffract/CustomDiffer.fs
@@ -1,0 +1,107 @@
+﻿namespace DEdge.Diffract
+
+open System
+open DEdge.Diffract
+
+[<Sealed; AbstractClass>]
+type CustomDiffer<'T> =
+
+    /// <summary>
+    /// Create a custom differ for a specific type.
+    /// </summary>
+    /// <param name="buildDiffFunction">Builds the diff function for this type.</param>
+    static member Build(buildDiffFunction: Func<IDifferFactory, Func<'T, 'T, Diff option>>) =
+        { new ICustomDiffer with
+            member this.GetCustomDiffer<'U>(differFactory, shape) =
+                if shape.Type = typeof<'T> then
+                    let diffFunction = buildDiffFunction.Invoke(differFactory)
+                    { new IDiffer<'T> with
+                        member _.Diff(x1, x2) = diffFunction.Invoke(x1, x2) }
+                    |> unbox<IDiffer<'U>>
+                    |> Some
+                else
+                    None }
+
+    /// <summary>
+    /// Create a custom differ for a specific type.
+    /// </summary>
+    /// <param name="buildDiffFunction">Builds the diff function for this type.</param>
+    static member Build(buildDiffFunction: IDifferFactory -> 'T -> 'T -> Diff option) =
+        { new ICustomDiffer with
+            member this.GetCustomDiffer<'U>(differFactory, shape) =
+                if shape.Type = typeof<'T> then
+                    let diffFunction = buildDiffFunction differFactory
+                    { new IDiffer<'T> with
+                        member _.Diff(x1, x2) = diffFunction x1 x2 }
+                    |> unbox<IDiffer<'U>>
+                    |> Some
+                else
+                    None }
+
+    /// <summary>
+    /// Create a custom differ for a specific type.
+    /// </summary>
+    /// <param name="diffFunction">The diff function for this type.</param>
+    static member Build(diffFunction: Func<'T, 'T, Diff option>) =
+        CustomDiffer.Build(fun _ -> diffFunction)
+
+    /// <summary>
+    /// Create a custom differ for a specific type by mapping it to a diffable type.
+    /// </summary>
+    /// <param name="mapFunction">The mapping function.</param>
+    /// <typeparam name="T">The type for which a custom differ is being created.</typeparam>
+    /// <typeparam name="U">The type used to actually perform the diff.</typeparam>
+    static member Map<'U>(mapFunction: Func<'T, 'U>) =
+        CustomDiffer<'T>.Build(fun differFactory ->
+            let differ = differFactory.GetDiffer<'U>()
+            fun x1 x2 -> differ.Diff(mapFunction.Invoke(x1), mapFunction.Invoke(x2)))
+
+[<Sealed; AbstractClass>]
+type CustomDiffer =
+
+    /// <summary>
+    /// Create a custom differ for a specific type.
+    /// </summary>
+    /// <param name="buildDiffFunction">Builds the diff function for this type.</param>
+    static member Build(buildDiffFunction: Func<IDifferFactory, Func<'T, 'T, Diff option>>) =
+        CustomDiffer<'T>.Build(buildDiffFunction)
+
+    /// <summary>
+    /// Create a custom differ for a specific type.
+    /// </summary>
+    /// <param name="buildDiffFunction">Builds the diff function for this type.</param>
+    static member Build(buildDiffFunction: IDifferFactory -> 'T -> 'T -> Diff option) =
+        CustomDiffer<'T>.Build(buildDiffFunction)
+
+    /// <summary>
+    /// Create a custom differ for a specific type.
+    /// </summary>
+    /// <param name="diffFunction">The diff function for this type.</param>
+    static member Build(diffFunction: Func<'T, 'T, Diff option>) =
+        CustomDiffer<'T>.Build(diffFunction)
+
+    /// <summary>
+    /// Create a custom differ for a leaf type using default comparison and a custom display format.
+    /// </summary>
+    /// <param name="format">The display format.</param>
+    static member Leaf<'T when 'T : equality> (format: Func<'T, string>) =
+        CustomDiffer.Build<'T>(fun x y ->
+            if x = y then
+                None
+            else
+                Diff.Value(format.Invoke(x), format.Invoke(y))
+                |> Some)
+
+    /// <summary>
+    /// Combine multiple custom differs.
+    /// </summary>
+    /// <param name="differs">The custom differs.</param>
+    static member Combine (differs: seq<ICustomDiffer>) =
+        CombinedCustomDiffer(differs) :> ICustomDiffer
+
+    /// <summary>
+    /// Combine multiple custom differs.
+    /// </summary>
+    /// <param name="differs">The custom differs.</param>
+    static member Combine ([<ParamArray>] differs: ICustomDiffer[]) =
+        CustomDiffer.Combine(differs :> seq<_>)

--- a/src/Diffract/Diffract.fsproj
+++ b/src/Diffract/Diffract.fsproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Types.fs" />
+    <Compile Include="CustomDiffer.fs" />
     <Compile Include="ReadOnlyDictionaryShape.fs" />
     <Compile Include="DictionaryShape.fs" />
     <Compile Include="Differ.fs" />

--- a/tests/Diffract.CSharp.Tests/CustomDiffers.cs
+++ b/tests/Diffract.CSharp.Tests/CustomDiffers.cs
@@ -26,6 +26,36 @@ namespace DEdge.Diffract.CSharp.Tests
             Assert.Equal(expectedDiff, actualDiff);
         }
 
+        [Fact]
+        public void CustomDifferWithCombinators()
+        {
+            var expectedDiff = "D Expect = \"a\"\n  Actual = \"b\"\n";
+            var expected = new Container(new CustomDiffable("a"));
+            var actual = new Container(new CustomDiffable("b"));
+            var actualDiff = MyDifferWithCombinators.Get<Container>().ToString(expected, actual);
+            Assert.Equal(expectedDiff, actualDiff);
+        }
+
+        [Fact]
+        public void CustomDifferWithMap()
+        {
+            var expectedDiff = "D Expect = \"a\"\n  Actual = \"b\"\n";
+            var expected = new Container(new CustomDiffable("a"));
+            var actual = new Container(new CustomDiffable("b"));
+            var actualDiff = MyDifferWithMap.Get<Container>().ToString(expected, actual);
+            Assert.Equal(expectedDiff, actualDiff);
+        }
+
+        [Fact]
+        public void CustomDifferWithMapToAnonymousObject()
+        {
+            var expectedDiff = "D.v Expect = \"a\"\n    Actual = \"b\"\n";
+            var expected = new Container(new CustomDiffable("a"));
+            var actual = new Container(new CustomDiffable("b"));
+            var actualDiff = MyDifferWithMapToAnonymousObject.Get<Container>().ToString(expected, actual);
+            Assert.Equal(expectedDiff, actualDiff);
+        }
+
         public record CustomDiffable(string X);
 
         public record Container(CustomDiffable D);
@@ -56,6 +86,49 @@ namespace DEdge.Diffract.CSharp.Tests
                         ? new MyDiffer(differFactory).Unwrap<CustomDiffable, T>()
                         : null;
             }
+        }
+
+        public static class MyDifferWithCombinators
+        {
+            public static IDiffer<T> Get<T>() => Singleton<T>.Instance;
+
+            private static class Singleton<T>
+            {
+                public static readonly IDiffer<T> Instance = CustomDiffer.GetDiffer<T>();
+            }
+
+            private static readonly ICustomDiffer CustomDiffer =
+                CustomDiffer<CustomDiffable>.Build(factory =>
+                {
+                    var stringDiffer = factory.GetDiffer<string>();
+                    return (x1, x2) => stringDiffer.Diff(x1.X, x2.X);
+                });
+        }
+
+        public static class MyDifferWithMap
+        {
+            public static IDiffer<T> Get<T>() => Singleton<T>.Instance;
+
+            private static class Singleton<T>
+            {
+                public static readonly IDiffer<T> Instance = CustomDiffer.GetDiffer<T>();
+            }
+
+            private static readonly ICustomDiffer CustomDiffer =
+                CustomDiffer<CustomDiffable>.Map(x => x.X);
+        }
+
+        public static class MyDifferWithMapToAnonymousObject
+        {
+            public static IDiffer<T> Get<T>() => Singleton<T>.Instance;
+
+            private static class Singleton<T>
+            {
+                public static readonly IDiffer<T> Instance = CustomDiffer.GetDiffer<T>();
+            }
+
+            private static readonly ICustomDiffer CustomDiffer =
+                CustomDiffer<CustomDiffable>.Map(x => new { v = x.X });
         }
     }
 }


### PR DESCRIPTION
Add `CustomDiffer` static classes with helpers to build differs for custom types more easily.

For example, let's take an interface with properties that we want to be able to diff based on the values of these properties.

```fsharp
type IMyInterface =
    abstract X: int
    abstract Y: string
```

One way to do the diff currently would be:

```fsharp
let diffableMyInterface (x: IMyInterface) =
    {| X = x.X; Y = x.Y |}

type MyCustomDiffer() =
    interface ICustomDiffer with
        member this.GetCustomDiffer<'T>(differFactory, shape) =
            if shape.Type = typeof<IMyInterface> then
                let differ = differFactory.GetDiffer()
                { new IDiffer<IUpdate> with
                    member _.Diff(x1, x2) = differ.Diff(diffableMyInterface x1, diffableMyInterface x2) }
                |> unbox<IDiffer<'T>>
                |> Some
            else
                None

let differ<'T> = MyCustomDiffer().GetDiffer<'T>()
```

It can be simplified using `CustomDiffer.Build`:

```fsharp
let diffableMyInterface (x: IMyInterface) =
    {| X = x.X; Y = x.Y |}

let myCustomDiffer = CustomDiffer<MyInterface>.Build(fun differFactory ->
    let differ = DifferFactory.GetDiffer()
    fun x1 x2 ->
        differ.Diff(diffableMyInterface x1, diffableMyInterface x2))

let differ<'T> = myCustomDiffer.GetDiffer<'T>()
```

and even further using `CustomDiffer.Map`:

```fsharp
let myCustomDiffer = CustomDiffer<IMyInterface>.Map(fun x -> {| X = x.X; Y = x.Y |})

let differ<'T> = myCustomDiffer.GetDiffer<'T>()
```

Equivalently in C# using anonymous objects:

```csharp
public static class MyCustomDiffer<T> {
    public static readonly IDiffer<T> Differ = MyCustomDiffer.Instance.GetDiffer<T>();
}

public static class MyCustomDiffer {
    public static readonly ICustomDiffer Instance =
        CustomDiffer<IMyInterface>.Map(x => new { X = x.X, Y = x.Y });
}
```

Additionally, to create a differ able to handle multiple custom types, there is `CustomDiffer.Combine`:

```fsharp
let myCustomDiffer = CustomDiffer.Combine [
    CustomDiffer<IMyInterface>.Map(fun x -> {| X = x.X; Y = x.Y |})
    CustomDiffer<IMyOtherInterface>.Map(fun x -> {| Z = x.Z; T = x.T |})
]
```

```csharp
public static class MyCustomDiffer {
    public static readonly ICustomDiffer Instance = CustomDiffer.Combine(
        CustomDiffer<IMyInterface>.Map(x => new { X = x.X, Y = x.Y }),
        CustomDiffer<IMyOtherInterface>.Map(x => new { Z = x.Z, T = x.T }));
}
```